### PR TITLE
build(release): make preflight portable on arm hosts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -31,6 +31,9 @@ Please include:
 - The runtime refuses mismatched real/effective UID execution contexts.
 - CI covers static analysis, shell linting, unit tests, sanitizers, package validation, fuzzing, and secret scanning.
 - The release-adjacent CI toolchain is snapshot-pinned so build and analysis jobs do not drift independently from the trusted builder.
+- The default branch requires pull-request review plus code-owner review for
+  contributed changes, while the single repository owner retains pull-request
+  bypass rights for self-maintained changes.
 - The Debian snapshot bootstrap path uses Debian archive signing plus the pinned base image digest for integrity. The initial snapshot fetch is plain HTTP because CA roots are not available until the first package install.
 - Releases are published only after `release-preflight` succeeds.
 - Public releases are built in GitHub Actions from signed annotated semver tags. The trusted builder workflow verifies the signed tag before building, uses the snapshot-pinned inputs recorded in `docker/release-builder.lock`, and the published release manifest records the commit digest and reproducible builder inputs that were built.

--- a/scripts/release-preflight.sh
+++ b/scripts/release-preflight.sh
@@ -19,6 +19,36 @@ validate_image_ref() {
 	fi
 }
 
+normalize_arch() {
+	local raw="$1"
+
+	case "${raw}" in
+		x86_64 | amd64)
+			printf '%s\n' amd64
+			;;
+		aarch64 | arm64)
+			printf '%s\n' arm64
+			;;
+		*)
+			echo "Unsupported container architecture: ${raw}" >&2
+			exit 1
+			;;
+	esac
+}
+
+resolve_prefight_platform() {
+	local server_arch
+
+	server_arch="$(
+		docker version --format '{{.Server.Arch}}' 2>/dev/null || true
+	)"
+	if [[ -z "${server_arch}" || "${server_arch}" == "<no value>" ]]; then
+		server_arch="$(uname -m)"
+	fi
+
+	printf 'linux/%s\n' "$(normalize_arch "${server_arch}")"
+}
+
 SCRIPT_DIR="$(
 	cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd
 )"
@@ -33,10 +63,14 @@ CONTAINER_UID_GID="$(id -u):$(id -g)"
 BUILDER_IMAGE="${BUILDER_IMAGE:-resetusb-release-builder:preflight}"
 PREFLIGHT_IMAGE="${PREFLIGHT_IMAGE:-resetusb-release-preflight:preflight}"
 GITLEAKS_IMAGE="${GITLEAKS_IMAGE:-zricethezav/gitleaks:v8.30.0@sha256:691af3c7c5a48b16f187ce3446d5f194838f91238f27270ed36eef6359a574d9}"
+RELEASE_PLATFORM="${RELEASE_PLATFORM:-linux/amd64}"
+PREFLIGHT_PLATFORM="${PREFLIGHT_PLATFORM:-$(resolve_prefight_platform)}"
+PREFLIGHT_BUILDER_IMAGE="${PREFLIGHT_BUILDER_IMAGE:-resetusb-release-builder:preflight-native}"
 
 validate_image_ref "BUILDER_IMAGE" "${BUILDER_IMAGE}"
 validate_image_ref "PREFLIGHT_IMAGE" "${PREFLIGHT_IMAGE}"
 validate_image_ref "GITLEAKS_IMAGE" "${GITLEAKS_IMAGE}"
+validate_image_ref "PREFLIGHT_BUILDER_IMAGE" "${PREFLIGHT_BUILDER_IMAGE}"
 
 require_cmd docker
 
@@ -47,12 +81,21 @@ cleanup() {
 trap cleanup EXIT
 
 echo "==> Building release builder image"
-"${BUILDER_ROOT}"/scripts/docker-build-release-builder.sh --platform=linux/amd64 \
+"${BUILDER_ROOT}"/scripts/docker-build-release-builder.sh --platform="${RELEASE_PLATFORM}" \
 	-f "${BUILDER_ROOT}/docker/release-builder.Dockerfile" \
 	-t "${BUILDER_IMAGE}" "${BUILDER_ROOT}"
 
+if [[ "${PREFLIGHT_PLATFORM}" == "${RELEASE_PLATFORM}" ]]; then
+	PREFLIGHT_BUILDER_IMAGE="${BUILDER_IMAGE}"
+else
+	echo "==> Building native preflight builder image"
+	"${BUILDER_ROOT}"/scripts/docker-build-release-builder.sh --platform="${PREFLIGHT_PLATFORM}" \
+		-f "${BUILDER_ROOT}/docker/release-builder.Dockerfile" \
+		-t "${PREFLIGHT_BUILDER_IMAGE}" "${BUILDER_ROOT}"
+fi
+
 cat >"${tmp_dockerfile}" <<EOF
-FROM ${BUILDER_IMAGE}
+FROM ${PREFLIGHT_BUILDER_IMAGE}
 ENV DEBIAN_FRONTEND=noninteractive
 RUN set -eux; \
     echo 'Acquire::Retries "6";' > /etc/apt/apt.conf.d/80-retries; \
@@ -67,11 +110,11 @@ RUN set -eux; \
 EOF
 
 echo "==> Building release preflight image"
-docker build --platform=linux/amd64 \
+docker build --platform="${PREFLIGHT_PLATFORM}" \
 	-f "${tmp_dockerfile}" -t "${PREFLIGHT_IMAGE}" "${BUILDER_ROOT}"
 
 echo "==> Running Linux release preflight"
-docker run --rm --platform=linux/amd64 \
+docker run --rm --platform="${PREFLIGHT_PLATFORM}" \
 	--user "${CONTAINER_UID_GID}" \
 	-v "${SOURCE_ROOT}":/source \
 	-w /source \

--- a/scripts/test-package-integration.sh
+++ b/scripts/test-package-integration.sh
@@ -385,9 +385,11 @@ run_deb_test() {
 				binary="$(find /tarball -type f -name resetusb | head -n 1)"
 				test -x "$binary"
 				find /tarball -type f -name "resetusb.8*" | grep -q .
-				ldd "$binary" | grep -q libusb
+				mkdir -p /tmp/tarball-bin
+				install -m 0755 "$binary" /tmp/tarball-bin/resetusb
+				ldd /tmp/tarball-bin/resetusb | grep -q libusb
 				set +e
-				su -s /bin/sh -c "$binary" tester >/tmp/tar.out 2>/tmp/tar.err
+				su -s /bin/sh -c /tmp/tarball-bin/resetusb tester >/tmp/tar.out 2>/tmp/tar.err
 				rc=$?
 				set -e
 				test "$rc" -ne 0
@@ -443,9 +445,11 @@ run_rpm_test() {
 				binary="$(find /tarball -type f -name resetusb | head -n 1)"
 				test -x "$binary"
 				find /tarball -type f -name "resetusb.8*" | grep -q .
-				ldd "$binary" | grep -q libusb
+				mkdir -p /tmp/tarball-bin
+				install -m 0755 "$binary" /tmp/tarball-bin/resetusb
+				ldd /tmp/tarball-bin/resetusb | grep -q libusb
 				set +e
-				su -s /bin/sh -c "$binary" tester >/tmp/tar.out 2>/tmp/tar.err
+				su -s /bin/sh -c /tmp/tarball-bin/resetusb tester >/tmp/tar.out 2>/tmp/tar.err
 				rc=$?
 				set -e
 				test "$rc" -ne 0

--- a/scripts/test-package-integration.sh
+++ b/scripts/test-package-integration.sh
@@ -14,6 +14,7 @@ DIST_DIR="${DIST_DIR:-${REPO_ROOT}/dist}"
 PACKAGE_TEST_IMAGE_LOCK_FILE="${PACKAGE_TEST_IMAGE_LOCK_FILE:-${REPO_ROOT}/docker/package-test-images.lock}"
 PACKAGE_TEST_CHANNELS="${PACKAGE_TEST_CHANNELS:-stable unstable}"
 PACKAGE_TEST_ARCHES="${PACKAGE_TEST_ARCHES:-amd64 arm64 armv7}"
+BINFMT_IMAGE="${BINFMT_IMAGE:-tonistiigi/binfmt@sha256:d3b963f787999e6c0219a48dba02978769286ff61a5f4d26245cb6a6e5567ea3}"
 SEMVER_RELEASE_TAG_REGEX='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
 DEV_ARTIFACT_VERSION_REGEX='^dev-[0-9a-f]{12}$'
 LOCKED_IMAGE_REF_REGEX='^[a-z0-9./_-]+(:[A-Za-z0-9._-]+)?@sha256:[0-9a-f]{64}$'
@@ -35,6 +36,13 @@ declare -A ARCH_RPM=(
 	[amd64]="x86_64"
 	[arm64]="aarch64"
 )
+
+declare -A ARCH_BINFMT=(
+	[arm64]="arm64"
+	[armv7]="arm"
+)
+
+declare -A PLATFORM_SUPPORT_VERIFIED=()
 
 validate_locked_image_ref() {
 	local name="$1"
@@ -81,6 +89,8 @@ load_package_test_image_lock() {
 
 		validate_locked_image_ref "${name}" "${!name}"
 	done
+
+	validate_locked_image_ref "BINFMT_IMAGE" "${BINFMT_IMAGE}"
 }
 
 resolve_package_test_image() {
@@ -151,6 +161,56 @@ require_artifact_version() {
 
 	echo "Unexpected artifact version: ${version}" >&2
 	exit 1
+}
+
+probe_platform_support() {
+	local arch="$1"
+	local image="$2"
+
+	docker run --rm \
+		--platform="${ARCH_PLATFORM[${arch}]}" \
+		--entrypoint /bin/sh \
+		"${image}" \
+		-c 'exit 0' >/dev/null 2>&1
+}
+
+ensure_platform_support() {
+	local arch="$1"
+	local image="$2"
+	local binfmt_arch="${ARCH_BINFMT[${arch}]:-}"
+
+	if [[ -n "${PLATFORM_SUPPORT_VERIFIED[${arch}]:-}" ]]; then
+		return
+	fi
+
+	if probe_platform_support "${arch}" "${image}"; then
+		PLATFORM_SUPPORT_VERIFIED["${arch}"]=1
+		return
+	fi
+
+	if [[ -n "${binfmt_arch}" ]]; then
+		docker run --privileged --rm "${BINFMT_IMAGE}" --install "${binfmt_arch}" >/dev/null
+		if probe_platform_support "${arch}" "${image}"; then
+			PLATFORM_SUPPORT_VERIFIED["${arch}"]=1
+			return
+		fi
+	fi
+
+	echo "Docker cannot execute ${ARCH_PLATFORM[${arch}]} containers. Install the required binfmt emulator or adjust PACKAGE_TEST_ARCHES." >&2
+	exit 1
+}
+
+with_extracted_tarball() {
+	local tarball_file="$1"
+	local callback="$2"
+	local extracted_dir
+	local rc=0
+
+	extracted_dir="$(mktemp -d "${WORK_ROOT}/.resetusb-tarball.XXXXXX")"
+	tar -xzf "${tarball_file}" -C "${extracted_dir}"
+	"${callback}" "${extracted_dir}" || rc=$?
+	rm -rf "${extracted_dir}"
+	return "${rc}"
 }
 
 discover_artifact_version() {
@@ -291,45 +351,51 @@ run_deb_test() {
 	require_artifact "${tarball_file}"
 	verify_artifact_checksum "${package_file}"
 	verify_artifact_checksum "${tarball_file}"
+	ensure_platform_support "${arch}" "${image}"
 
 	echo "==> ${distro}/${channel}/${arch}"
-	docker run --rm \
-		--platform="${ARCH_PLATFORM[${arch}]}" \
-		-v "${WORK_ROOT}":/work:ro \
-		-v "${DIST_DIR}":/dist:ro \
-		-w /work \
-		"${image}" \
-		sh -euxc '
-			export DEBIAN_FRONTEND=noninteractive
-			apt-get update
-			apt-get install -y --no-install-recommends ca-certificates passwd
-			dpkg-deb -I /dist/'"$(basename "${package_file}")"' | grep -q "Package: resetusb"
-			dpkg-deb -I /dist/'"$(basename "${package_file}")"' | grep -q "Architecture: '"${package_arch}"'"
-			dpkg-deb -c /dist/'"$(basename "${package_file}")"' | grep -Eq "usr/share/man/man8/resetusb\\.8(\\.gz)?$"
-			apt-get install -y /dist/'"$(basename "${package_file}")"'
-			test -x /usr/sbin/resetusb
-			ldd /usr/sbin/resetusb | grep -q libusb
-			useradd -m tester
-			set +e
-			su -s /bin/sh -c /usr/sbin/resetusb tester >/tmp/pkg.out 2>/tmp/pkg.err
-			rc=$?
-			set -e
-			test "$rc" -ne 0
-			grep -q "Must be root" /tmp/pkg.err
+	run_deb_test_with_tarball_mount() {
+		local extracted_dir="$1"
 
-			mkdir -p /tmp/tarball
-			tar -xzf /dist/'"$(basename "${tarball_file}")"' -C /tmp/tarball
-			binary="$(find /tmp/tarball -type f -name resetusb | head -n 1)"
-			test -x "$binary"
-			find /tmp/tarball -type f -name "resetusb.8*" | grep -q .
-			ldd "$binary" | grep -q libusb
-			set +e
-			su -s /bin/sh -c "$binary" tester >/tmp/tar.out 2>/tmp/tar.err
-			rc=$?
-			set -e
-			test "$rc" -ne 0
-			grep -q "Must be root" /tmp/tar.err
-		'
+		docker run --rm \
+			--platform="${ARCH_PLATFORM[${arch}]}" \
+			-v "${WORK_ROOT}":/work:ro \
+			-v "${DIST_DIR}":/dist:ro \
+			-v "${extracted_dir}":/tarball:ro \
+			-w /work \
+			"${image}" \
+			sh -euxc '
+				export DEBIAN_FRONTEND=noninteractive
+				apt-get update
+				apt-get install -y --no-install-recommends ca-certificates passwd
+				dpkg-deb -I /dist/'"$(basename "${package_file}")"' | grep -q "Package: resetusb"
+				dpkg-deb -I /dist/'"$(basename "${package_file}")"' | grep -q "Architecture: '"${package_arch}"'"
+				dpkg-deb -c /dist/'"$(basename "${package_file}")"' | grep -Eq "usr/share/man/man8/resetusb\\.8(\\.gz)?$"
+				apt-get install -y /dist/'"$(basename "${package_file}")"'
+				test -x /usr/sbin/resetusb
+				ldd /usr/sbin/resetusb | grep -q libusb
+				useradd -m tester
+				set +e
+				su -s /bin/sh -c /usr/sbin/resetusb tester >/tmp/pkg.out 2>/tmp/pkg.err
+				rc=$?
+				set -e
+				test "$rc" -ne 0
+				grep -q "Must be root" /tmp/pkg.err
+
+				binary="$(find /tarball -type f -name resetusb | head -n 1)"
+				test -x "$binary"
+				find /tarball -type f -name "resetusb.8*" | grep -q .
+				ldd "$binary" | grep -q libusb
+				set +e
+				su -s /bin/sh -c "$binary" tester >/tmp/tar.out 2>/tmp/tar.err
+				rc=$?
+				set -e
+				test "$rc" -ne 0
+				grep -q "Must be root" /tmp/tar.err
+			'
+	}
+
+	with_extracted_tarball "${tarball_file}" run_deb_test_with_tarball_mount
 }
 
 run_rpm_test() {
@@ -346,42 +412,48 @@ run_rpm_test() {
 	require_artifact "${tarball_file}"
 	verify_artifact_checksum "${package_file}"
 	verify_artifact_checksum "${tarball_file}"
+	ensure_platform_support "${arch}" "${image}"
 
 	echo "==> fedora/${channel}/${arch}"
-	docker run --rm \
-		--platform="${ARCH_PLATFORM[${arch}]}" \
-		-v "${WORK_ROOT}":/work:ro \
-		-v "${DIST_DIR}":/dist:ro \
-		-w /work \
-		"${image}" \
-		sh -euxc '
-			rpm -qpi /dist/'"$(basename "${package_file}")"' | grep -Eq "^Name[[:space:]]*: resetusb$"
-			rpm -qpi /dist/'"$(basename "${package_file}")"' | grep -Eq "^Architecture[[:space:]]*: '"${rpm_arch}"'$"
-			rpm -qlp /dist/'"$(basename "${package_file}")"' | grep -Eq "^/usr/share/man/man8/resetusb\\.8(\\.gz)?$"
-			dnf install -y shadow-utils util-linux /dist/'"$(basename "${package_file}")"'
-			test -x /usr/sbin/resetusb
-			ldd /usr/sbin/resetusb | grep -q libusb
-			useradd -m tester
-			set +e
-			su -s /bin/sh -c /usr/sbin/resetusb tester >/tmp/pkg.out 2>/tmp/pkg.err
-			rc=$?
-			set -e
-			test "$rc" -ne 0
-			grep -q "Must be root" /tmp/pkg.err
+	run_rpm_test_with_tarball_mount() {
+		local extracted_dir="$1"
 
-			mkdir -p /tmp/tarball
-			tar -xzf /dist/'"$(basename "${tarball_file}")"' -C /tmp/tarball
-			binary="$(find /tmp/tarball -type f -name resetusb | head -n 1)"
-			test -x "$binary"
-			find /tmp/tarball -type f -name "resetusb.8*" | grep -q .
-			ldd "$binary" | grep -q libusb
-			set +e
-			su -s /bin/sh -c "$binary" tester >/tmp/tar.out 2>/tmp/tar.err
-			rc=$?
-			set -e
-			test "$rc" -ne 0
-			grep -q "Must be root" /tmp/tar.err
-		'
+		docker run --rm \
+			--platform="${ARCH_PLATFORM[${arch}]}" \
+			-v "${WORK_ROOT}":/work:ro \
+			-v "${DIST_DIR}":/dist:ro \
+			-v "${extracted_dir}":/tarball:ro \
+			-w /work \
+			"${image}" \
+			sh -euxc '
+				rpm -qpi /dist/'"$(basename "${package_file}")"' | grep -Eq "^Name[[:space:]]*: resetusb$"
+				rpm -qpi /dist/'"$(basename "${package_file}")"' | grep -Eq "^Architecture[[:space:]]*: '"${rpm_arch}"'$"
+				rpm -qlp /dist/'"$(basename "${package_file}")"' | grep -Eq "^/usr/share/man/man8/resetusb\\.8(\\.gz)?$"
+				dnf install -y shadow-utils util-linux /dist/'"$(basename "${package_file}")"'
+				test -x /usr/sbin/resetusb
+				ldd /usr/sbin/resetusb | grep -q libusb
+				useradd -m tester
+				set +e
+				su -s /bin/sh -c /usr/sbin/resetusb tester >/tmp/pkg.out 2>/tmp/pkg.err
+				rc=$?
+				set -e
+				test "$rc" -ne 0
+				grep -q "Must be root" /tmp/pkg.err
+
+				binary="$(find /tarball -type f -name resetusb | head -n 1)"
+				test -x "$binary"
+				find /tarball -type f -name "resetusb.8*" | grep -q .
+				ldd "$binary" | grep -q libusb
+				set +e
+				su -s /bin/sh -c "$binary" tester >/tmp/tar.out 2>/tmp/tar.err
+				rc=$?
+				set -e
+				test "$rc" -ne 0
+				grep -q "Must be root" /tmp/tar.err
+			'
+	}
+
+	with_extracted_tarball "${tarball_file}" run_rpm_test_with_tarball_mount
 }
 
 main() {

--- a/scripts/verify-release-reproducibility.sh
+++ b/scripts/verify-release-reproducibility.sh
@@ -108,7 +108,11 @@ if [[ ! -d "${DIST_DIR}" ]]; then
 fi
 
 source_date_epoch="$(resolve_source_date_epoch)"
-repro_check_dir="$(mktemp -d "${TMPDIR:-/tmp}/resetusb-repro-check.XXXXXX")"
+# On macOS/Colima bind mounts, directories created under TMPDIR can appear as
+# root-owned inside the Linux container even when the caller UID is mapped
+# through. Creating the scratch tree under SOURCE_ROOT keeps the rebuild output
+# writable to the unprivileged container user we use for reproducibility checks.
+repro_check_dir="$(mktemp -d "${SOURCE_ROOT}/.resetusb-repro-check.XXXXXX")"
 repro_dist_dir="${repro_check_dir}/dist"
 mkdir -p "${repro_dist_dir}"
 cleanup() {


### PR DESCRIPTION
## Summary
- make `release-preflight` run its compile/lint/sanitize stages on the host container architecture while preserving `linux/amd64` for the actual release builder
- teach package integration checks to bootstrap pinned `binfmt` emulation when needed and validate tarball contents from a host-extracted tree
- keep reproducibility scratch space under the repo root on macOS/Colima and document the single-maintainer branch protection posture

## Validation
- `./scripts/release-preflight.sh`
- `PACKAGE_TEST_ARCHES=armv7 PACKAGE_TEST_CHANNELS='stable unstable' ./scripts/test-package-integration.sh`
- `PACKAGE_TEST_CHANNELS=unstable PACKAGE_TEST_ARCHES=amd64 ./scripts/test-package-integration.sh`
- `./scripts/verify-release-reproducibility.sh`
