### PR TITLE
Update security baseline Go runtime

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.25.7"
+          go-version: "1.26.4"
           check-latest: true
           cache: false
 


### PR DESCRIPTION
Summary:
- Update the security-baseline workflow Go runtime to 1.26.4.

Verification:
- actionlint
- zizmor --format json .github/workflows
- make lint
- Codex simplify/correctness review loop clean