### PR TITLE
chore: refresh release workflow tooling

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -252,7 +252,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Run release package smoke checks
         env:
           BUILDER_IMAGE: resetusb-release-builder:${{ github.sha }}

--- a/.github/workflows/nightly-deep.yml
+++ b/.github/workflows/nightly-deep.yml
@@ -22,6 +22,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Run full release-style preflight
         run: ./scripts/release-preflight.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
           git -C source rev-parse --verify "refs/tags/${RELEASE_TAG}^{tag}" >/dev/null
           git -C source -c gpg.program=gpg verify-tag "${RELEASE_TAG}"
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Run release preflight
         env:
           GITHUB_REF_NAME: ${{ needs.release-context.outputs.release_tag }}


### PR DESCRIPTION
## Summary
- refresh docker/setup-qemu-action to the current official release in release/package workflows

## Verification
- make check-format
- make lint
- make test (Linux-only tests skipped on Darwin by project Makefile)
- actionlint
- zizmor .github/workflows .github/dependabot.yml
