### PR TITLE
chore: prepare resetusb v2.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.0.15
+
+- Refresh the pinned `docker/setup-qemu-action` workflow dependency used by CI,
+  nightly release preflight, and release publication.
+
 ## v2.0.14
 
 - Refresh the pinned Debian `trixie` base image used by CI containers and the


### PR DESCRIPTION
## Summary
- add resetusb v2.0.15 changelog notes for the QEMU workflow pin refresh

## Verification
- `make check-format`
- `make lint`
- `make test` (repo skipped Linux-only tests on Darwin)
- `git diff --check`
